### PR TITLE
Update sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,3 +6,4 @@ sonar.javascript.file.suffixes=.js,.jsx
 sonar.typescript.file.suffixes=.ts,.tsx 
 sonar.sourceEncoding=UTF-8
 sonar.javasript.lcov.reportPaths=./coverage/lcov.info
+sonar.exclusions=**/*.test.*


### PR DESCRIPTION
Foi inserido filtro de exclusão no sonar para que considere todos os arquivos que contenham *.test.* em sua nomenclatura